### PR TITLE
refactor: fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Yargs Interactive
+
 [![Build Status](https://travis-ci.org/nanovazquez/yargs-interactive.svg?branch=master)](https://travis-ci.org/nanovazquez/yargs-interactive) [![Coverage Status](https://coveralls.io/repos/github/nanovazquez/yargs-interactive/badge.svg)](https://coveralls.io/github/nanovazquez/yargs-interactive) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![npm](https://img.shields.io/npm/v/yargs-interactive.svg?style=flat)](https://www.npmjs.com/package/yargs-interactive)
 [![npm](https://img.shields.io/npm/dw/yargs-interactive.svg)](https://www.npmjs.com/package/yargs-interactive)
 
@@ -21,28 +22,24 @@ Then, add this code in your CLI code to get all the arguments parsed:
 ```js
 #!/usr/bin/env node
 
-const yargsInteractive = require('yargs-interactive');
+const yargsInteractive = require("yargs-interactive");
 const options = {
-  name: { type: 'input', default: 'A robot', describe: 'Enter your name' },
-  likesPizza: { type: 'confirm', default: false, describe: 'Do you like pizza?' },
+  name: { type: "input", default: "A robot", describe: "Enter your name" },
+  likesPizza: { type: "confirm", default: false, describe: "Do you like pizza?" }
 };
 
 yargsInteractive()
-  .usage('$0 <command> [args]')
+  .usage("$0 <command> [args]")
   .interactive(options)
-  .then((result) => {
+  .then(result => {
     // Your business logic goes here.
     // Get the arguments from the result
     // e.g. myCli(result.name);
-      console.log(
-        `\nResult is:\n`
-        + `- Name: ${result.name}\n`
-        + `- Likes pizza: ${result.likesPizza}\n`
-      );
+    console.log(`\nResult is:\n` + `- Name: ${result.name}\n` + `- Likes pizza: ${result.likesPizza}\n`);
   });
 ```
 
-Now, by simply wrapping your CLI code with this tool, you'll get all the information you need from the user. For instance, save the previous snipped in a file named *my-cli.js* and run it in your terminal:
+Now, by simply wrapping your CLI code with this tool, you'll get all the information you need from the user. For instance, save the previous snipped in a file named _my-cli.js_ and run it in your terminal:
 
 ```
 ➜ node my-cli.js --interactive
@@ -55,36 +52,36 @@ Now, by simply wrapping your CLI code with this tool, you'll get all the informa
 ## Usage
 
 It supports the following use cases
-* [Prompt questions with default values (full-interactive)](#prompt-questions-with-default-values-full-interactive)
-* [Prompt just some questions (mixed mode)](#prompt-just-some-questions-mixed-mode)
-* [No prompt at all (ye olde yargs)](#no-prompt-at-all-ye-olde-yargs)
 
-### Prompt questions with default values (full-interactive)
+- [Prompt all questions](#prompt-questions-with-default-values-full-interactive)
+- [Prompt some questions (mixed mode)](#prompt-just-some-questions-mixed-mode)
+- [No prompt at all (ye olde yargs)](#no-prompt-at-all-ye-olde-yargs)
+
+### Prompt questions (full-interactive)
 
 **my-cli.js**
+
 ```js
-const yargsInteractive = require('yargs-interactive');
+const yargsInteractive = require("yargs-interactive");
 
 const options = {
   name: {
-    type: 'input',
-    default: 'nano',
-    describe: 'Enter your name'
+    type: "input",
+    describe: "Enter your name"
   },
   likesPizza: {
-    type: 'confirm',
-    default: false,
-    describe: 'Do you like pizza?'
-  },
+    type: "confirm",
+    describe: "Do you like pizza?"
+  }
 };
 
 yargsInteractive()
-  .usage('$0 <command> [args]')
+  .usage("$0 <command> [args]")
   .interactive(options)
-  .then((result) => {
+  .then(result => {
     // The tool will prompt questions and will output your answers.
     // TODO: Do something with the result (e.g result.name)
-    console.log(result)
+    console.log(result);
   });
 ```
 
@@ -122,39 +119,42 @@ And then simply call your CLI with no parameters.
 
 ### Options
 
-| Property   | Type         | Description                   |
-| ---------- | -------------| ----------------------------- |
-| type       |  string      | _(Required)_ The type of the option to prompt (e.g. `input`, `confirm`, etc.). **We provide all prompt types supported by [Inquirer](https://github.com/SBoudrias/Inquirer.js/#prompt-types).**|
-| describe   |  string      | _(Required)_ The message to display when prompting the option (e.g. `Do you like pizza?`) |
-| default    |  any         | The default value of the option. |
-| prompt     |  string      | _(Default is `if-empty`)_ Property to decide whether to prompt the option or not. Possible values: `always`, `never`, `if-no-arg` (prompts if the option was not sent via command line parameters) and `if-empty` (prompts if the value was not sent via command line parameters and it doesn't have a default property). |
+| Property | Type   | Description                                                                                                                                                                                                                                                                                                               |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type     | string | _(Required)_ The type of the option to prompt (e.g. `input`, `confirm`, etc.). **We provide all prompt types supported by [Inquirer](https://github.com/SBoudrias/Inquirer.js/#prompt-types).**                                                                                                                           |
+| describe | string | _(Required)_ The message to display when prompting the option (e.g. `Do you like pizza?`)                                                                                                                                                                                                                                 |
+| default  | any    | The default value of the option.                                                                                                                                                                                                                                                                                          |
+| prompt   | string | _(Default is `if-empty`)_ Property to decide whether to prompt the option or not. Possible values: `always`, `never`, `if-no-arg` (prompts if the option was not sent via command line parameters) and `if-empty` (prompts if the value was not sent via command line parameters and it doesn't have a default property). |
 
-### Prompt just some questions (mixed mode)
+### Prompt some questions (mixed mode)
 
-You can opt-out options from interactive mode by setting the `prompt` property to `never`. By default, its value is `if-empty`, prompting the question to the user if the value was not set via command line parameters or it doesn't have a default property. Setting to `if-no-arg` will only prompt the question if no argument is provided. Lastly, you can use `always` to always prompt the option.
+You can opt-out options from interactive mode by setting the `prompt` property to `never`. By default, its value is `if-empty`, prompting the question to the user if the value was not set via command line parameters, or if it doesn't have a default property. Setting it to `if-no-arg` will prompt the question if no argument is provided. Lastly, you can use `always` to _always prompt the option_.
 
 **my-cli.js**
+
 ```js
-const yargsInteractive = require('yargs-interactive');
+const yargsInteractive = require("yargs-interactive");
 
 const options = {
   name: {
-    // prompt property if not set defaults to 'if-empty'
-    type: 'input',
-    describe: 'Enter your name'
+    // prompt property, if not set, defaults to 'if-empty'
+    // In this case, it means the question will be prompted
+    // if it is not provided by args, as it doesn't have a default value.
+    type: "input",
+    describe: "Enter your name"
   },
   likesPizza: {
-    type: 'confirm',
+    type: "confirm",
     default: false,
-    describe: 'Do you like pizza?',
-    prompt: 'never' // because everyone likes pizza
-  },
+    describe: "Do you like pizza?",
+    prompt: "never" // because everyone likes pizza
+  }
 };
 
 yargsInteractive()
-  .usage('$0 <command> [args]')
+  .usage("$0 <command> [args]")
   .interactive(options)
-  .then((result) => {
+  .then(result => {
     // The tool will prompt questions output the answers.
     // You can opt-out options by using `prompt: 'never'`. For these properties, it
     // will use the value sent by parameter (--likesPizza) or the default value.
@@ -164,6 +164,7 @@ yargsInteractive()
 ```
 
 **Usage in terminal**
+
 ```
 ➜ node my-cli.js --interactive
 ```
@@ -173,26 +174,27 @@ Notice that if you enter `node my-cli.js --name='Johh' --interactive` name won't
 ### No prompt at all (ye olde yargs)
 
 **my-cli.js**
+
 ```js
-const yargsInteractive = require('yargs-interactive');
+const yargsInteractive = require("yargs-interactive");
 
 const options = {
   name: {
-    type: 'input',
-    default: 'nano',
-    describe: 'Enter your name'
+    type: "input",
+    default: "nano",
+    describe: "Enter your name"
   },
   likesPizza: {
-    type: 'confirm',
+    type: "confirm",
     default: false,
-    describe: 'Do you like pizza?'
-  },
+    describe: "Do you like pizza?"
+  }
 };
 
 yargsInteractive()
-  .usage('$0 <command> [args]')
+  .usage("$0 <command> [args]")
   .interactive(options)
-  .then((result) => {
+  .then(result => {
     // The tool will output the values set via parameters or
     // the default value (if not provided).
     // TODO: Do something with the result (e.g result.name)
@@ -201,6 +203,7 @@ yargsInteractive()
 ```
 
 **Usage in terminal**
+
 ```
 ➜ node my-cli.js --name='Johh' --likesPizza
 ```

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -4,12 +4,12 @@
  * Usage 1:
  * 1) Open a terminal.
  * 2) Enter: node ./examples/basic.js --name='John'
- * Result: Output should have John as name and the default value of likesPizza (false).
+ * Result: Outputs John as name and the default value of likesPizza (false).
  *
  * Usage 2:
  * 1) Open a terminal.
  * 2) Enter: node ./examples/basic.js --name='John' --likesPizza
- *    Result: Output should have John as name and likesPizza set to true
+ *    Result: Outputs John as name and likesPizza set to true
  *
  * Usage 3:
  * 1) Open a terminal.
@@ -19,7 +19,7 @@
  * Usage 4:
  * 1) Open a terminal.
  * 2) Enter: node ./examples/basic.js --interactive
- *    Result: he tool will prompt questions and will output the answers.
+ *    Result: the tool will prompt all questions and will output the user answers.
  */
 
 const yargsInteractive = require('../src');
@@ -28,22 +28,20 @@ const options = {
   name: {
     type: 'input',
     default: 'A robot',
+    prompt: 'if-no-arg',
     describe: 'Enter your name'
   },
   likesPizza: {
     type: 'confirm',
     default: false,
+    prompt: 'if-no-arg',
     describe: 'Do you like pizza?'
-  },
+  }
 };
 
 yargsInteractive()
     .usage('$0 <command> [args]')
     .interactive(options)
     .then((result) => {
-      console.log(
-          `\nResult is:\n`
-        + `- Name: ${result.name}\n`
-        + `- Likes pizza: ${result.likesPizza}\n`
-      );
+      console.log(`\nResult is:\n` + `- Name: ${result.name}\n` + `- Likes pizza: ${result.likesPizza}\n`);
     });

--- a/examples/full-interactive.js
+++ b/examples/full-interactive.js
@@ -3,35 +3,28 @@
 /*
  * Usage:
  * 1) Open a terminal.
- * 2) Enter: node ./examples/full-interactive.js'
+ * 2) Enter: node ./examples/full-interactive.js
  * Result: The tool will prompt questions and will output the answers.
  */
 const yargsInteractive = require('../src');
 
 const options = {
   interactive: {
-    default: true,
+    default: true
   },
   name: {
     type: 'input',
-    default: 'nano',
     describe: 'Enter your name'
   },
   likesPizza: {
     type: 'confirm',
-    default: false,
     describe: 'Do you like pizza?'
-  },
+  }
 };
 
 yargsInteractive()
     .usage('$0 <command> [args]')
     .interactive(options)
     .then((result) => {
-      console.log(
-          `\nResult is:\n`
-        + `- Name: ${result.name}\n`
-        + `- Likes pizza: ${result.likesPizza}\n`
-      );
+      console.log(`\nResult is:\n` + `- Name: ${result.name}\n` + `- Likes pizza: ${result.likesPizza}\n`);
     });
-

--- a/examples/prompt.js
+++ b/examples/prompt.js
@@ -4,12 +4,12 @@
  * Usage 1:
  * 1) Open a terminal.
  * 2) Enter: node ./examples/prompt.js --interactive
- * Result: The tool will prompt question for namem and likesPizza.
+ * Result: The tool will ask for the name (as pizza has a default value and, by default, we don't prompt args with values)
  *
  * Usage 2:
  * 1) Open a terminal.
  * 2) Enter: node ./examples/prompt.js --name="John"
- * Result: The tool will prompt question for likesPizza but not for the name (it was sent via parameter).
+ * Result: The tool won't prompt as it has all it needs. If you want to configure this, see the "prompt" option in the README.
  */
 
 const yargsInteractive = require('../src');
@@ -17,23 +17,18 @@ const yargsInteractive = require('../src');
 const options = {
   name: {
     type: 'input',
-    describe: 'Enter your name',
-    prompt: 'if-empty'
+    describe: 'Enter your name'
   },
   likesPizza: {
     type: 'confirm',
     default: false,
     describe: 'Do you like pizza?'
-  },
+  }
 };
 
 yargsInteractive()
     .usage('$0 <command> [args]')
     .interactive(options)
     .then((result) => {
-      console.log(
-          `\nResult is:\n`
-        + `- Name: ${result.name}\n`
-        + `- Likes pizza: ${result.likesPizza}\n`
-      );
+      console.log(`\nResult is:\n` + `- Name: ${result.name}\n` + `- Likes pizza: ${result.likesPizza}\n`);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,7 +1949,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -2124,6 +2125,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -2133,17 +2135,20 @@
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -2161,8 +2166,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3646,6 +3650,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -4322,7 +4327,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
@@ -4907,6 +4913,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -5140,8 +5151,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-subset": {
       "version": "0.1.1",
@@ -5200,8 +5210,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -6007,6 +6016,14 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "lcov-parse": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
@@ -6340,6 +6357,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -6675,6 +6693,21 @@
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
+        }
+      }
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         }
       }
     },
@@ -10485,7 +10518,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -10493,8 +10525,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.1.4",
@@ -10646,6 +10677,61 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "requires": {
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -10682,8 +10768,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
@@ -10695,6 +10780,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -10703,6 +10789,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -10732,7 +10819,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -10797,8 +10885,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -11013,6 +11100,11 @@
         "module-not-found-error": "^1.0.1",
         "resolve": "^1.11.1"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.3.0",
@@ -11304,7 +11396,8 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.12.0",
@@ -11516,6 +11609,12 @@
         "yargs": "^14.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11543,6 +11642,12 @@
           "requires": {
             "lru-cache": "^5.1.1"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -11616,6 +11721,72 @@
             "read-pkg": "^5.1.1",
             "type-fest": "^0.5.0"
           }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+          "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -11669,7 +11840,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -11677,8 +11847,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
       "version": "0.7.6",
@@ -12131,8 +12300,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -12654,7 +12822,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -12689,6 +12856,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -12698,17 +12866,20 @@
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -12767,7 +12938,8 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yallist": {
       "version": "3.0.3",
@@ -12776,41 +12948,167 @@
       "dev": true
     },
     "yargs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
-      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "requires": {
-        "cliui": "^5.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
+        "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^2.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
       },
       "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "emoji-regex": "^7.0.1",
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -12819,6 +13117,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/nanovazquez/yargs-interactive#readme",
   "dependencies": {
     "inquirer": "^7.0.0",
-    "yargs": "^14.0.0"
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",

--- a/src/filter-object.js
+++ b/src/filter-object.js
@@ -1,9 +1,9 @@
 /**
  * Filter keys in an object based on a condition.
- * @param {Object} element - The element whose keys will be filtered.
- * @param {any} condition - (value, key) => boolean
+ * @param {object} element The element whose keys will be filtered.
+ * @param {any} condition (value, key) => boolean
  * The condition to execute in each key value (i.e. if condition(value, key) returns true, the key is kept).
- * @return {object} - A new object with only the keys that pass the condition.
+ * @return {object} A new object with only the keys that pass the condition.
  */
 module.exports = (element = {}, condition = () => true) => {
   const toReturn = {};

--- a/src/interactive-mode.js
+++ b/src/interactive-mode.js
@@ -1,20 +1,21 @@
 const inquirer = require('inquirer');
 
-const interactiveMode = {
-  interactiveMode(values = {}) {
-    const prompt = inquirer.createPromptModule();
-    const questions = Object.keys(values).map((key) => {
-      const value = values[key];
-      return Object.assign({}, value, {
-        name: key,
-        type: value.type,
-        message: value.describe,
-        default: value.default,
-      });
+/**
+ * Initiate an interactive prompt to get values from the user.
+ * @param {object} values The values to configure the prompt
+ * @return {object} A promise that, when fullfilled, will contain answer of the questions prompted to the user
+ */
+module.exports = (values) => {
+  const prompt = inquirer.createPromptModule();
+  const questions = Object.keys(values).map((key) => {
+    const value = values[key];
+    return Object.assign({}, value, {
+      name: key,
+      type: value.type,
+      message: value.describe,
+      default: value.default
     });
+  });
 
-    return prompt(questions);
-  }
+  return prompt(questions);
 };
-
-module.exports = interactiveMode;

--- a/src/is-args-provided.js
+++ b/src/is-args-provided.js
@@ -1,8 +1,8 @@
 /**
  * Checks if the argument received is provided in the argument collection
- * @param {Object} arg - The arg to check (e.g. `likesPizza`)
- * @param {Object} processArgs - The collection of process arguments (e.g. `["--interactive", "--likesPizza=true"]`)
- * @return {boolean} - Returns true if the argument is present in the collection of process arguments, false otherwise.
+ * @param {Object} arg The arg to check (e.g. `likesPizza`)
+ * @param {Object} processArgs The collection of process arguments (e.g. `["--interactive", "--likesPizza=true"]`)
+ * @return {boolean} True if the argument is present in the collection of process arguments, false otherwise.
  */
 module.exports = (arg, processArgs) => {
   return processArgs.some((argProvided) => argProvided === `--${arg}` || argProvided.startsWith(`--${arg}=`));

--- a/src/yargs-interactive.js
+++ b/src/yargs-interactive.js
@@ -1,5 +1,5 @@
 const yargs = require('yargs');
-const {interactiveMode} = require('./interactive-mode');
+const interactiveMode = require('./interactive-mode');
 const filterObject = require('./filter-object');
 const isEmpty = require('./is-empty');
 const isArgProvided = require('./is-args-provided');
@@ -45,9 +45,7 @@ const yargsInteractive = (processArgs = process.argv.slice(2), cwd) => {
     });
 
     // Check if we should get the values from the interactive mode
-    return argv.interactive
-      ? interactiveMode(interactiveOptions).then((result) => Object.assign({}, argv, result))
-      : Promise.resolve(argv);
+    return argv.interactive ? interactiveMode(interactiveOptions).then((result) => Object.assign({}, argv, result)) : Promise.resolve(argv);
   };
 
   return yargsConfig;


### PR DESCRIPTION
I've made some small changes to the original PR. Could you please review them and merge it with your master? 

In short, by applying this PR:

* Yargs version is reverted to 10.x, making no change in the main repo. This is only to split the development changes with the main version change, that requires a major. We can do it safely in a new, one-line PR.
* The tests to validate if the `interactiveMode()` function is called or not was added back to the suite, by using jest's mock feature instead of proxyRequire. This change also fixes the test suite execution.
* Examples and code documention is (slightly) updated.
* InteractiveMode module returns a function instead of an object, just like before, to keep consistency with the rest of the modules.